### PR TITLE
Replaced expired Percona key

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -95,7 +95,7 @@ mariadb__apt_key: '{{ mariadb__apt_key_map[mariadb__flavor] | d() }}'
 # downloaded if any of the listed flavors is selected.
 mariadb__apt_key_map:
   'mariadb_upstream': [ '199369E5404BD5FC7D2FE43BCBCB082A1BB943DB', '177F4010FE56CA3336300305F1656F24C74CD1D8' ]
-  'percona':          '430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A'
+  'percona':          '4D1BB29D63D98E422B2113B19334A25F8507EFA5'
 
                                                                    # ]]]
 # .. envvar:: mariadb__upstream_version [[[


### PR DESCRIPTION
Replaced expired Percona key with new: pub  4096R/8507EFA5 2016-06-30

http://eu.pool.sks-keyservers.net/pks/lookup?op=vindex&fingerprint=on&search=0x9334A25F8507EFA5