### PR TITLE
Fix 'mariadb__delegate_to' fallback to use 'inventory_hostname'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,14 @@ Added
 
 - Support MySQL-Galera flavor from Codership. [ganto]
 
+Changed
+~~~~~~~
+
+- Use ``inventory_hostname`` as fallback for task delegation which should render
+  manual definition of ``mariadb__delegate_to`` unnecessary in case the client
+  and server are setup on the same host and the inventory name doesn't
+  correspond with the FQDN of the host. [ganto]
+
 
 `debops.mariadb v0.2.2`_ - 2016-08-01
 -------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,5 @@
+.. _mariadb__ref_changelog:
+
 Changelog
 =========
 
@@ -7,6 +9,9 @@ This project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html
 and `human-readable changelog <http://keepachangelog.com/>`_.
 
 The current role maintainer is drybjed.
+
+Refer to the :ref:`mariadb__ref_upgrade_notes` when you intend to upgrade to a
+new release.
 
 
 `debops.mariadb master`_ - unreleased

--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -1,0 +1,48 @@
+.. _mariadb__ref_upgrade_notes:
+
+Upgrade notes
+=============
+
+The upgrade notes only describe necessary changes that you might need to make
+to your setup in order to use a new role release. Refer to the
+:ref:`mariadb__ref_changelog` for more details about what has changed.
+
+
+From v0.2.2 to v0.3.0
+---------------------
+
+Due to the new definition of :envvar:`mariadb__delegate_to` all users of the
+role are impacted under the following conditions:
+
+- The Ansible inventory name is different from the FQDN for the hosts where
+  this role is applied to.
+
+  **AND**
+
+- For the those hosts the :envvar:`mariadb__server` variable is not defined
+  in the Ansible inventory which means the default value is used during role
+  execution.
+
+  **AND**
+
+- For thos hosts the :envvar:`mariadb__delegate_to` variable was not defined
+  in the Ansible inventory which means the default value is used during role
+  execution.
+
+The first time the new version of the role is run standalone and/or as a
+dependency of Ansible roles every user account defined through
+:envvar:`mariadb__users`, :envvar:`mariadb__dependent_users` or
+:envvar:`mariadb_users` will change its secrets path which will regenerate
+the database user password. This may result in an inaccessible database in
+case those passwords are also used externally. Ansible roles which are
+accessing the ``delegate_to`` value through the local facts (usually to access
+the password via secrets lookup) will automatically learn the new path and don't
+need to be changed. Mechanisms which get the password via manually defined
+secrets path MUST be updated accordingly.
+
+This impact can be avoided by manually adding the following definition to the
+Ansible inventory of the affected hosts:
+
+.. code-block:: yaml
+
+   mariadb__delegate_to: '{{ ansible_fqdn }}'

--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -32,7 +32,7 @@ role are impacted under the following conditions:
 The first time the new version of the role is run standalone and/or as a
 dependency of Ansible roles every user account defined through
 :envvar:`mariadb__users`, :envvar:`mariadb__dependent_users` or
-:envvar:`mariadb_users` will change its secrets path which will regenerate
+``mariadb_users`` will change its secrets path which will regenerate
 the database user password. This may result in an inaccessible database in
 case those passwords are also used externally. Ansible roles which are
 accessing the ``delegate_to`` value through the local facts (usually to access

--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -25,7 +25,7 @@ role are impacted under the following conditions:
 
   **AND**
 
-- For thos hosts the :envvar:`mariadb__delegate_to` variable was not defined
+- For thos hosts the :envvar:`mariadb__delegate_to` variable is not defined
   in the Ansible inventory which means the default value is used during role
   execution.
 
@@ -33,8 +33,8 @@ The first time the new version of the role is run standalone and/or as a
 dependency of Ansible roles every user account defined through
 :envvar:`mariadb__users`, :envvar:`mariadb__dependent_users` or
 ``mariadb_users`` will change its secrets path which will regenerate
-the database user password. This may result in an inaccessible database in
-case those passwords are also used externally. Ansible roles which are
+the database user password. **This may result in an inaccessible database in
+case those passwords are also used externally.** Ansible roles which are
 accessing the ``delegate_to`` value through the local facts (usually to access
 the password via secrets lookup) will automatically learn the new path and don't
 need to be changed. Mechanisms which get the password via manually defined

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,13 +40,13 @@ mariadb__client: '{{ ansible_fqdn }}'
 # correct host. This variable controls the task delegation to the correct
 # database server.
 #
-# If the MariaDB server is run locally, this should point to the FQDN hostname of
-# the current host, NOT ``localhost`` because that would delegate the tasks to
-# the Ansible Controller.
+# If the MariaDB server is run locally, this should point to the inventory name
+# of the current host, NOT ``localhost`` because that would delegate the tasks
+# to the Ansible Controller.
 mariadb__delegate_to: '{{ mariadb__server
                           if (mariadb__server|d() and
                               mariadb__server != "localhost")
-                          else ansible_fqdn }}'
+                          else inventory_hostname }}'
                                                                    # ]]]
                                                                    # ]]]
 # MariaDB APT packages [[[

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Ansible role: debops.mariadb
    defaults-configuration
    copyright
    changelog
+   upgrade
 
 ..
  Local Variables:

--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -1,0 +1,1 @@
+.. include:: ../UPGRADE.rst


### PR DESCRIPTION
`delegate_to` values should always refer to an Ansible inventory
name and shouldn't be confused with the FQDN. There might be valid
reasons that they don't correspond with each other (e.g. Vagrant).

Fixes #27