### PR TITLE
Adjust to Galera repository changes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -89,7 +89,8 @@ mariadb__flavor_map:
 # .. envvar:: mariadb__apt_key [[[
 #
 # String or list of GPG keys which should be added to the APT key database to
-# authenticate the external repositories.
+# authenticate the external repositories. If this value is set to `False` no
+# extra APT key will be added.
 mariadb__apt_key: '{{ mariadb__apt_key_map[mariadb__flavor] | d() }}'
 
                                                                    # ]]]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,6 +67,9 @@ mariadb__delegate_to: '{{ mariadb__server
 # - ``mysql-5.6_galera-3``: use MySQL 5.6 engine with Galera from Codership
 #   repository
 #
+# - ``mysql-5.7_galera-3``: use MySQL 5.7 engine with Galera from Codership
+#   repository
+#
 # - ``percona``: use Percona XtraDB engine from upstream repository
 #
 # The choice depends on availability of MariaDB packages in a distribution.
@@ -102,6 +105,7 @@ mariadb__apt_key: '{{ mariadb__apt_key_map[mariadb__flavor] | d() }}'
 mariadb__apt_key_map:
   'mariadb_upstream':   [ '199369E5404BD5FC7D2FE43BCBCB082A1BB943DB', '177F4010FE56CA3336300305F1656F24C74CD1D8' ]
   'mysql-5.6_galera-3': '44B7345738EBDE52594DAD80D669017EBC19DDBA'
+  'mysql-5.7_galera-3': '44B7345738EBDE52594DAD80D669017EBC19DDBA'
   'percona':            '4D1BB29D63D98E422B2113B19334A25F8507EFA5'
 
                                                                    # ]]]
@@ -124,7 +128,8 @@ mariadb__upstream_mirror: 'http://nyc2.mirrors.digitalocean.com/mariadb/repo/{{ 
 # if any of the listed flavors is selected.
 mariadb__apt_repository_map:
   'mariadb_upstream':   'deb {{ mariadb__upstream_mirror }} {{ ansible_distribution_release }} main'
-  'mysql-5.6_galera-3': 'deb http://releases.galeracluster.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main'
+  'mysql-5.6_galera-3': 'deb http://releases.galeracluster.com/mysql-wsrep-5.6/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main'
+  'mysql-5.7_galera-3': 'deb http://releases.galeracluster.com/mysql-wsrep-5.7/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main'
   'percona':            'deb http://repo.percona.com/apt {{ ansible_distribution_release }} main'
 
                                                                    # ]]]
@@ -150,6 +155,7 @@ mariadb__packages_map:
   'mariadb_upstream': [ 'mariadb-client' ]
   'mysql': [ 'mysql-client' ]
   'mysql-5.6_galera-3': [ 'mysql-wsrep-client-5.6' ]
+  'mysql-5.7_galera-3': [ 'mysql-wsrep-client-5.7' ]
   'percona': [ 'percona-server-client' ]
                                                                    # ]]]
                                                                    # ]]]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,8 @@
   with_flattened: '{{ ([ mariadb__apt_key ]
                        if mariadb__apt_key is string
                        else mariadb__apt_key) }}'
-  when: mariadb__flavor in [ 'mariadb_upstream', 'percona' ]
+  when: (mariadb__flavor not in [ 'mariadb', 'mysql' ]) and
+        mariadb__apt_key
 
 - name: Add custom APT repository
   apt_repository:
@@ -31,7 +32,7 @@
     state: 'present'
     update_cache: True
     mode: '0644'
-  when: mariadb__flavor in [ 'mariadb_upstream', 'percona' ]
+  when: mariadb__flavor in mariadb__apt_repository_map.keys()
 
 - name: Check if local database port is open
   command: nc -z localhost {{ mariadb__port }}


### PR DESCRIPTION
This is the MySQL client change following debops/ansible-mariadb_server#45, adjusting to the apt repository URL changes at [releases.codership.com](http://releases.codership.com) and introducing the latest Galera release for MySQL 5.7.